### PR TITLE
feat: add axis labels and scale limits

### DIFF
--- a/ocss-curves/src/App.tsx
+++ b/ocss-curves/src/App.tsx
@@ -26,9 +26,9 @@ export default function App() {
         let carbon = scenario.startCarbon;
         pts.push({ time: 0, temperature: temp, carbon });
 
-        const steps = [...scenario.steps].sort((a, b) => a.start - b.start);
-        steps.forEach((s) => {
-            const startMs = s.start * 60 * 1000;
+        let currentTime = 0;
+        scenario.steps.forEach((s) => {
+            const startMs = currentTime * 60 * 1000;
             pts.push({ time: startMs, temperature: temp, carbon });
             if (s.type === "temperature") {
                 const rampEnd = startMs + s.ramp * 60 * 1000;
@@ -36,15 +36,18 @@ export default function App() {
                 pts.push({ time: rampEnd, temperature: temp, carbon });
                 const end = rampEnd + s.duration * 60 * 1000;
                 pts.push({ time: end, temperature: temp, carbon });
+                currentTime += s.ramp + s.duration;
             } else if (s.type === "carbon") {
                 const rampEnd = startMs + s.ramp * 60 * 1000;
                 carbon = s.target;
                 pts.push({ time: rampEnd, temperature: temp, carbon });
                 const end = rampEnd + s.duration * 60 * 1000;
                 pts.push({ time: end, temperature: temp, carbon });
+                currentTime += s.ramp + s.duration;
             } else {
                 const end = startMs + s.duration * 60 * 1000;
                 pts.push({ time: end, temperature: temp, carbon });
+                currentTime += s.duration;
             }
         });
         return pts;

--- a/ocss-curves/src/App.tsx
+++ b/ocss-curves/src/App.tsx
@@ -1,12 +1,33 @@
-import React, { useState, useRef, useEffect } from "react";
-import { useSimulation } from "./hooks/useSimulation";
+import { useState, useRef, useEffect, useMemo } from "react";
+import { useSimulation, type ScenarioStep } from "./hooks/useSimulation";
 import Chart from "./components/Chart";
 import Controls from "./components/Controls";
 import Sliders from "./components/Sliders";
 import Alarm from "./components/Alarm";
+import ScenarioEditor from "./components/ScenarioEditor";
 
 export default function App() {
-    const sim = useSimulation(860);
+    const [scenario, setScenario] = useState<ScenarioStep[]>([]);
+    const sim = useSimulation(860, 100, scenario);
+
+    const scenarioPoints = useMemo(() => {
+        let time = 0;
+        const pts: { time: number; temperature: number; carbon: number }[] = [];
+        scenario.forEach((step) => {
+            pts.push({
+                time,
+                temperature: step.tempFrom,
+                carbon: step.carbonFrom,
+            });
+            time += step.duration * 60 * 1000;
+            pts.push({
+                time,
+                temperature: step.tempTo,
+                carbon: step.carbonTo,
+            });
+        });
+        return pts;
+    }, [scenario]);
 
     const [chartWidth, setChartWidth] = useState(1200);
     const [chartHeight, setChartHeight] = useState(600);
@@ -32,6 +53,7 @@ export default function App() {
             <div ref={containerRef}>
                 <Chart
                     data={sim.data}
+                    scenario={scenarioPoints}
                     chartWidth={chartWidth}
                     chartHeight={chartHeight}
                     containerRef={containerRef}
@@ -69,6 +91,8 @@ export default function App() {
                 alarmMargin={sim.alarmMargin}
                 setAlarmMargin={sim.setAlarmMargin}
             />
+
+            <ScenarioEditor scenario={scenario} setScenario={setScenario} />
 
             <Alarm alarm={sim.alarm} avgCarbon={sim.avgCarbon} alarmMargin={sim.alarmMargin} onAcknowledge={sim.acknowledgeAlarm} />
 

--- a/ocss-curves/src/App.tsx
+++ b/ocss-curves/src/App.tsx
@@ -12,19 +12,17 @@ export default function App() {
 
     const scenarioPoints = useMemo(() => {
         let time = 0;
+        let lastTemp = 0;
+        let lastCarbon = 0;
         const pts: { time: number; temperature: number; carbon: number }[] = [];
         scenario.forEach((step) => {
-            pts.push({
-                time,
-                temperature: step.tempFrom,
-                carbon: step.carbonFrom,
-            });
+            if (step.tempFrom !== undefined) lastTemp = step.tempFrom;
+            if (step.carbonFrom !== undefined) lastCarbon = step.carbonFrom;
+            pts.push({ time, temperature: lastTemp, carbon: lastCarbon });
             time += step.duration * 60 * 1000;
-            pts.push({
-                time,
-                temperature: step.tempTo,
-                carbon: step.carbonTo,
-            });
+            if (step.tempTo !== undefined) lastTemp = step.tempTo;
+            if (step.carbonTo !== undefined) lastCarbon = step.carbonTo;
+            pts.push({ time, temperature: lastTemp, carbon: lastCarbon });
         });
         return pts;
     }, [scenario]);

--- a/ocss-curves/src/App.tsx
+++ b/ocss-curves/src/App.tsx
@@ -164,8 +164,8 @@ export default function App() {
           color: white;
           background: #111;
           max-width: 100vw;
-          max-height: 100vh;
-          overflow: hidden;
+          min-height: 100vh;
+          overflow-y: auto;
           box-sizing: border-box;
           display: flex;
           flex-direction: column;

--- a/ocss-curves/src/App.tsx
+++ b/ocss-curves/src/App.tsx
@@ -16,12 +16,18 @@ export default function App() {
         let lastCarbon = 0;
         const pts: { time: number; temperature: number; carbon: number }[] = [];
         scenario.forEach((step) => {
-            if (step.tempFrom !== undefined) lastTemp = step.tempFrom;
-            if (step.carbonFrom !== undefined) lastCarbon = step.carbonFrom;
+            if (step.type === "temperature") {
+                lastTemp = step.from;
+            } else if (step.type === "carbon") {
+                lastCarbon = step.from;
+            }
             pts.push({ time, temperature: lastTemp, carbon: lastCarbon });
             time += step.duration * 60 * 1000;
-            if (step.tempTo !== undefined) lastTemp = step.tempTo;
-            if (step.carbonTo !== undefined) lastCarbon = step.carbonTo;
+            if (step.type === "temperature") {
+                lastTemp = step.to;
+            } else if (step.type === "carbon") {
+                lastCarbon = step.to;
+            }
             pts.push({ time, temperature: lastTemp, carbon: lastCarbon });
         });
         return pts;

--- a/ocss-curves/src/App.tsx
+++ b/ocss-curves/src/App.tsx
@@ -50,8 +50,29 @@ export default function App() {
                 const rampEnd = start + s.ramp * 60 * 1000;
                 carbon = s.target;
                 carbonEvents.push({ time: rampEnd, carbon });
+
                 const end = rampEnd + s.duration * 60 * 1000;
-                carbonEvents.push({ time: end, carbon });
+
+                if (s.effects && s.effects.length > 0) {
+                    const sorted = [...s.effects].sort(
+                        (a, b) => a.start - b.start
+                    );
+                    let currentOffset = 0;
+                    sorted.forEach((eff) => {
+                        const effStart = start + eff.start * 60 * 1000;
+                        const effEnd = effStart + eff.duration * 60 * 1000;
+                        carbonEvents.push({ time: effStart, carbon: carbon + currentOffset });
+                        currentOffset = eff.offset;
+                        carbonEvents.push({ time: effStart, carbon: carbon + currentOffset });
+                        carbonEvents.push({ time: effEnd, carbon: carbon + currentOffset });
+                        currentOffset = 0;
+                        carbonEvents.push({ time: effEnd, carbon: carbon });
+                    });
+                    carbonEvents.push({ time: end, carbon });
+                } else {
+                    carbonEvents.push({ time: end, carbon });
+                }
+
                 carbonTime += s.ramp + s.duration;
             }
         });

--- a/ocss-curves/src/App.tsx
+++ b/ocss-curves/src/App.tsx
@@ -8,6 +8,7 @@ import ScenarioEditor from "./components/ScenarioEditor";
 
 export default function App() {
     const [scenario, setScenario] = useState<ScenarioStep[]>([]);
+    const [editingScenario, setEditingScenario] = useState(false);
     const sim = useSimulation(860, 100, scenario);
 
     const scenarioPoints = useMemo(() => {
@@ -96,7 +97,14 @@ export default function App() {
                 setAlarmMargin={sim.setAlarmMargin}
             />
 
-            <ScenarioEditor scenario={scenario} setScenario={setScenario} />
+            {editingScenario ? (
+                <div>
+                    <ScenarioEditor scenario={scenario} setScenario={setScenario} />
+                    <button onClick={() => setEditingScenario(false)}>Stäng scenario</button>
+                </div>
+            ) : (
+                <button onClick={() => setEditingScenario(true)}>Skapa scenario</button>
+            )}
 
             <Alarm alarm={sim.alarm} avgCarbon={sim.avgCarbon} alarmMargin={sim.alarmMargin} onAcknowledge={sim.acknowledgeAlarm} />
 

--- a/ocss-curves/src/App.tsx
+++ b/ocss-curves/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo } from "react";
-import { useSimulation, type ScenarioStep } from "./hooks/useSimulation";
+import { useSimulation, type Scenario, DEFAULTS } from "./hooks/useSimulation";
 import Chart from "./components/Chart";
 import Controls from "./components/Controls";
 import Sliders from "./components/Sliders";
@@ -7,23 +7,32 @@ import Alarm from "./components/Alarm";
 import ScenarioEditor from "./components/ScenarioEditor";
 
 export default function App() {
-    const [scenario, setScenario] = useState<ScenarioStep[]>([]);
+    const [scenario, setScenario] = useState<Scenario>({
+        startTemp: 0,
+        startCarbon: DEFAULTS.carbonTarget,
+        steps: [],
+    });
     const [editingScenario, setEditingScenario] = useState(false);
-    const sim = useSimulation(860, 100, scenario);
+    const sim = useSimulation(
+        scenario.startTemp,
+        scenario.startCarbon,
+        100,
+        scenario.steps
+    );
 
     const scenarioPoints = useMemo(() => {
         const times = new Set<number>();
         times.add(0);
-        scenario.forEach((s) => {
+        scenario.steps.forEach((s) => {
             times.add(s.start);
             times.add(s.start + s.duration);
         });
         const sorted = [...times].sort((a, b) => a - b);
         const pts: { time: number; temperature: number; carbon: number }[] = [];
         sorted.forEach((t) => {
-            let temp = 0;
-            let carbon = 0;
-            scenario.forEach((s) => {
+            let temp = scenario.startTemp;
+            let carbon = scenario.startCarbon;
+            scenario.steps.forEach((s) => {
                 const start = s.start;
                 if (t < start) return;
                 const progress = Math.min(1, (t - start) / Math.max(1, s.duration));

--- a/ocss-curves/src/components/Alarm.tsx
+++ b/ocss-curves/src/components/Alarm.tsx
@@ -1,6 +1,11 @@
-import React from "react";
+type Props = {
+    alarm: boolean;
+    avgCarbon: number;
+    alarmMargin: number;
+    onAcknowledge: () => void;
+};
 
-export default function Alarm({ alarm, avgCarbon, alarmMargin, onAcknowledge }) {
+export default function Alarm({ alarm, avgCarbon, alarmMargin, onAcknowledge }: Props) {
     if (!alarm) return null;
 
     return (

--- a/ocss-curves/src/components/Chart.tsx
+++ b/ocss-curves/src/components/Chart.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 
+const MAX_TEMP = 1600;
+const MAX_CARBON = 1.6;
+
 type AlarmEvent = { time: number; value: number };
 
 type Props = {
@@ -39,10 +42,13 @@ export default function Chart({
         ((t - minTime) / (maxTime - minTime)) * (width - pad * 2) + pad;
 
     const scaleTempY = (val: number, height: number, pad: number) =>
-        height - ((val - 0) / targetTemp) * (height - pad * 2);
+        height - ((val - 0) / MAX_TEMP) * (height - pad * 2);
 
     const scaleCarbonY = (val: number, height: number, pad: number) =>
-        height - ((val - 0) / 2) * (height - pad * 2);
+        height - ((val - 0) / MAX_CARBON) * (height - pad * 2);
+
+    const tempTicks = Array.from({ length: 5 }, (_, i) => (MAX_TEMP / 4) * i);
+    const carbonTicks = Array.from({ length: 5 }, (_, i) => (MAX_CARBON / 4) * i);
 
     const buildPath = (
         key: "temperature" | "carbon" | "carbonAvg",
@@ -69,6 +75,47 @@ export default function Chart({
                 preserveAspectRatio="xMidYMid meet"
                 style={{width: "100%", height: "100%", display: "block"}}
             >
+                {/* Axes */}
+                <line
+                    x1={padding}
+                    x2={padding}
+                    y1={padding}
+                    y2={chartHeight - padding}
+                    stroke="#555"
+                />
+                <line
+                    x1={chartWidth - padding}
+                    x2={chartWidth - padding}
+                    y1={padding}
+                    y2={chartHeight - padding}
+                    stroke="#555"
+                />
+
+                {tempTicks.map((t) => (
+                    <text
+                        key={`temp-${t}`}
+                        x={padding - 10}
+                        y={scaleTempY(t, chartHeight, padding) + 4}
+                        fontSize={12}
+                        fill="red"
+                        textAnchor="end"
+                    >
+                        {t}
+                    </text>
+                ))}
+
+                {carbonTicks.map((c) => (
+                    <text
+                        key={`carbon-${c}`}
+                        x={chartWidth - padding + 10}
+                        y={scaleCarbonY(c, chartHeight, padding) + 4}
+                        fontSize={12}
+                        fill="green"
+                        textAnchor="start"
+                    >
+                        {c.toFixed(1)}
+                    </text>
+                ))}
                 {/* Temperature */}
                 <path
                     d={buildPath("temperature", scaleTempY, chartWidth, chartHeight, padding)}

--- a/ocss-curves/src/components/Controls.tsx
+++ b/ocss-curves/src/components/Controls.tsx
@@ -1,6 +1,11 @@
-import React from "react";
+type Props = {
+    onStart: () => void;
+    onStop: () => void;
+    setSpeed: (v: number) => void;
+    onDefaults: () => void;
+};
 
-export default function Controls({ onStart, onStop, setSpeed, onDefaults }) {
+export default function Controls({ onStart, onStop, setSpeed, onDefaults }: Props) {
     return (
         <div className="controls">
             <button

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -20,7 +20,6 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                 ...scenario.steps,
                 {
                     type: "carbon",
-                    start: 0,
                     target: scenario.startCarbon,
                     ramp: 10,
                     duration: 0,
@@ -108,16 +107,6 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                             <option value="temperature">Temperatur</option>
                             <option value="controls">Manipulering</option>
                         </select>
-                    </label>
-                    <label>
-                        Start (min):
-                        <input
-                            type="number"
-                            value={step.start}
-                            onChange={(e) =>
-                                updateStep(i, { start: +e.target.value })
-                            }
-                        />
                     </label>
                     {(step.type === "carbon" || step.type === "temperature") && (
                         <>

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -16,7 +16,7 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
     const addStep = () =>
         setScenario([
             ...scenario,
-            { type: "carbon", duration: 10, from: 0, to: 0 } as ScenarioStep,
+            { type: "carbon", start: 0, duration: 10, from: 0, to: 0 } as ScenarioStep,
         ]);
 
     const removeStep = (index: number) =>
@@ -60,7 +60,17 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                         </select>
                     </label>
                     <label>
-                        Tid (min):
+                        Start (min):
+                        <input
+                            type="number"
+                            value={step.start}
+                            onChange={(e) =>
+                                updateStep(i, { start: +e.target.value })
+                            }
+                        />
+                    </label>
+                    <label>
+                        Längd (min):
                         <input
                             type="number"
                             value={step.duration}

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -109,35 +109,17 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                             value={step.type}
                             onChange={(e) => {
                                 const type = e.target.value as ScenarioStep["type"];
-                                if (type === "controls") {
-                                    updateStep(i, {
-                                        type,
-                                        from: {
-                                            responsiveness: DEFAULTS.responsiveness,
-                                            noise: DEFAULTS.noise,
-                                            offset: DEFAULTS.offset,
-                                            alarmMargin: DEFAULTS.alarmMargin,
-                                        },
-                                        to: {
-                                            responsiveness: DEFAULTS.responsiveness,
-                                            noise: DEFAULTS.noise,
-                                            offset: DEFAULTS.offset,
-                                            alarmMargin: DEFAULTS.alarmMargin,
-                                        },
-                                    } as ScenarioStep);
-                                } else {
-                                    updateStep(i, {
-                                        type,
-                                        target: 0,
-                                        ramp: 0,
-                                        duration: 0,
-                                    } as ScenarioStep);
-                                }
+                                updateStep(i, {
+                                    type,
+                                    target: 0,
+                                    ramp: 0,
+                                    duration: 0,
+                                    effect: undefined,
+                                } as ScenarioStep);
                             }}
                         >
                             <option value="carbon">Kolhalt</option>
                             <option value="temperature">Temperatur</option>
-                            <option value="controls">Manipulering</option>
                         </select>
                     </label>
                     {(step.type === "carbon" || step.type === "temperature") && (
@@ -175,162 +157,144 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                                     }
                                 />
                             </label>
-                        </>
-                    )}
-                    {step.type === "controls" && (
-                        <>
-                            <label>
-                                Varaktighet (min):
-                                <input
-                                    type="number"
-                                    value={step.duration}
-                                    onChange={(e) =>
-                                        updateStep(i, { duration: +e.target.value })
-                                    }
-                                />
-                            </label>
-                            <div className="controls-fields">
-                                <div className="field-pair">
+                            {step.type === "carbon" && (
+                                <>
                                     <label>
-                                        Responsiveness från:
+                                        Manipulering från (min):
                                         <input
                                             type="number"
-                                            step={0.01}
                                             min={0}
-                                            max={1}
-                                            value={step.from.responsiveness}
+                                            max={step.ramp + step.duration}
+                                            value={step.effect?.start ?? 0}
                                             onChange={(e) =>
                                                 updateStep(i, {
-                                                    from: {
-                                                        ...step.from,
-                                                        responsiveness: +e.target.value,
+                                                    effect: {
+                                                        ...(step.effect ?? {
+                                                            responsiveness:
+                                                                DEFAULTS.responsiveness,
+                                                            noise: DEFAULTS.noise,
+                                                            offset: DEFAULTS.offset,
+                                                            alarmMargin:
+                                                                DEFAULTS.alarmMargin,
+                                                        }),
+                                                        start: +e.target.value,
                                                     },
                                                 })
                                             }
                                         />
                                     </label>
-                                    <label>
-                                        till:
-                                        <input
-                                            type="number"
-                                            step={0.01}
-                                            min={0}
-                                            max={1}
-                                            value={step.to.responsiveness}
-                                            onChange={(e) =>
-                                                updateStep(i, {
-                                                    to: {
-                                                        ...step.to,
-                                                        responsiveness: +e.target.value,
-                                                    },
-                                                })
-                                            }
-                                        />
-                                    </label>
-                                </div>
-                                <div className="field-pair">
-                                    <label>
-                                        Noise från:
-                                        <input
-                                            type="number"
-                                            step={0.01}
-                                            min={0}
-                                            max={1}
-                                            value={step.from.noise}
-                                            onChange={(e) =>
-                                                updateStep(i, {
-                                                    from: { ...step.from, noise: +e.target.value },
-                                                })
-                                            }
-                                        />
-                                    </label>
-                                    <label>
-                                        till:
-                                        <input
-                                            type="number"
-                                            step={0.01}
-                                            min={0}
-                                            max={1}
-                                            value={step.to.noise}
-                                            onChange={(e) =>
-                                                updateStep(i, {
-                                                    to: { ...step.to, noise: +e.target.value },
-                                                })
-                                            }
-                                        />
-                                    </label>
-                                </div>
-                                <div className="field-pair">
-                                    <label>
-                                        Offset från:
-                                        <input
-                                            type="number"
-                                            step={0.01}
-                                            min={-1}
-                                            max={1}
-                                            value={step.from.offset}
-                                            onChange={(e) =>
-                                                updateStep(i, {
-                                                    from: { ...step.from, offset: +e.target.value },
-                                                })
-                                            }
-                                        />
-                                    </label>
-                                    <label>
-                                        till:
-                                        <input
-                                            type="number"
-                                            step={0.01}
-                                            min={-1}
-                                            max={1}
-                                            value={step.to.offset}
-                                            onChange={(e) =>
-                                                updateStep(i, {
-                                                    to: { ...step.to, offset: +e.target.value },
-                                                })
-                                            }
-                                        />
-                                    </label>
-                                </div>
-                                <div className="field-pair">
-                                    <label>
-                                        Alarm-marginal från:
-                                        <input
-                                            type="number"
-                                            step={0.01}
-                                            min={0}
-                                            max={1}
-                                            value={step.from.alarmMargin}
-                                            onChange={(e) =>
-                                                updateStep(i, {
-                                                    from: {
-                                                        ...step.from,
-                                                        alarmMargin: +e.target.value,
-                                                    },
-                                                })
-                                            }
-                                        />
-                                    </label>
-                                    <label>
-                                        till:
-                                        <input
-                                            type="number"
-                                            step={0.01}
-                                            min={0}
-                                            max={1}
-                                            value={step.to.alarmMargin}
-                                            onChange={(e) =>
-                                                updateStep(i, {
-                                                    to: {
-                                                        ...step.to,
-                                                        alarmMargin: +e.target.value,
-                                                    },
-                                                })
-                                            }
-                                        />
-                                    </label>
-                                </div>
-                            </div>
+                                    <div className="controls-fields">
+                                        <div className="field-pair">
+                                            <label>
+                                                Responsiveness:
+                                                <input
+                                                    type="number"
+                                                    step={0.01}
+                                                    min={0}
+                                                    max={1}
+                                                    value={step.effect?.responsiveness ?? DEFAULTS.responsiveness}
+                                                    onChange={(e) =>
+                                                        updateStep(i, {
+                                                            effect: {
+                                                                ...(step.effect ?? {
+                                                                    start: 0,
+                                                                    noise:
+                                                                        DEFAULTS.noise,
+                                                                    offset:
+                                                                        DEFAULTS.offset,
+                                                                    alarmMargin:
+                                                                        DEFAULTS.alarmMargin,
+                                                                }),
+                                                                responsiveness:
+                                                                    +e.target.value,
+                                                            },
+                                                        })
+                                                    }
+                                                />
+                                            </label>
+                                            <label>
+                                                Noise:
+                                                <input
+                                                    type="number"
+                                                    step={0.01}
+                                                    min={0}
+                                                    max={1}
+                                                    value={step.effect?.noise ?? DEFAULTS.noise}
+                                                    onChange={(e) =>
+                                                        updateStep(i, {
+                                                            effect: {
+                                                                ...(step.effect ?? {
+                                                                    start: 0,
+                                                                    responsiveness:
+                                                                        DEFAULTS.responsiveness,
+                                                                    offset:
+                                                                        DEFAULTS.offset,
+                                                                    alarmMargin:
+                                                                        DEFAULTS.alarmMargin,
+                                                                }),
+                                                                noise: +e.target.value,
+                                                            },
+                                                        })
+                                                    }
+                                                />
+                                            </label>
+                                        </div>
+                                        <div className="field-pair">
+                                            <label>
+                                                Offset:
+                                                <input
+                                                    type="number"
+                                                    step={0.01}
+                                                    min={-1}
+                                                    max={1}
+                                                    value={step.effect?.offset ?? DEFAULTS.offset}
+                                                    onChange={(e) =>
+                                                        updateStep(i, {
+                                                            effect: {
+                                                                ...(step.effect ?? {
+                                                                    start: 0,
+                                                                    responsiveness:
+                                                                        DEFAULTS.responsiveness,
+                                                                    noise: DEFAULTS.noise,
+                                                                    alarmMargin:
+                                                                        DEFAULTS.alarmMargin,
+                                                                }),
+                                                                offset: +e.target.value,
+                                                            },
+                                                        })
+                                                    }
+                                                />
+                                            </label>
+                                            <label>
+                                                Alarm-marginal:
+                                                <input
+                                                    type="number"
+                                                    step={0.01}
+                                                    min={0}
+                                                    max={1}
+                                                    value={step.effect?.alarmMargin ?? DEFAULTS.alarmMargin}
+                                                    onChange={(e) =>
+                                                        updateStep(i, {
+                                                            effect: {
+                                                                ...(step.effect ?? {
+                                                                    start: 0,
+                                                                    responsiveness:
+                                                                        DEFAULTS.responsiveness,
+                                                                    noise: DEFAULTS.noise,
+                                                                    offset:
+                                                                        DEFAULTS.offset,
+                                                                }),
+                                                                alarmMargin:
+                                                                    +e.target.value,
+                                                            },
+                                                        })
+                                                    }
+                                                />
+                                            </label>
+                                        </div>
+                                    </div>
+                                </>
+                            )}
                         </>
                     )}
                     <button onClick={() => removeStep(i)}>Ta bort</button>

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -104,6 +104,7 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                 >
                     <div
                         className="drag-handle"
+                        title="Dra för att flytta"
                         draggable
                         onDragStart={() => handleDragStart(i)}
                         onDragEnd={() => setDragIndex(null)}
@@ -130,26 +131,28 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                         </label>
                         {(step.type === "carbon" || step.type === "temperature") && (
                             <>
-                                <label>
-                                    Tid till börvärde (min):
-                                    <input
-                                        type="number"
-                                        value={step.ramp}
-                                        onChange={(e) =>
-                                            updateStep(i, { ramp: +e.target.value })
-                                        }
-                                    />
-                                </label>
-                                <label>
-                                    Varaktighet (min):
-                                    <input
-                                        type="number"
-                                        value={step.duration}
-                                        onChange={(e) =>
-                                            updateStep(i, { duration: +e.target.value })
-                                        }
-                                    />
-                                </label>
+                                <div className="field-pair">
+                                    <label>
+                                        Tid till börvärde (min):
+                                        <input
+                                            type="number"
+                                            value={step.ramp}
+                                            onChange={(e) =>
+                                                updateStep(i, { ramp: +e.target.value })
+                                            }
+                                        />
+                                    </label>
+                                    <label>
+                                        Varaktighet (min):
+                                        <input
+                                            type="number"
+                                            value={step.duration}
+                                            onChange={(e) =>
+                                                updateStep(i, { duration: +e.target.value })
+                                            }
+                                        />
+                                    </label>
+                                </div>
                                 <label>
                                     Börvärde:
                                     <input

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -1,4 +1,4 @@
-import { type ScenarioStep } from "../hooks/useSimulation";
+import { type ScenarioStep, DEFAULTS } from "../hooks/useSimulation";
 
 type Props = {
     scenario: ScenarioStep[];
@@ -7,7 +7,9 @@ type Props = {
 
 export default function ScenarioEditor({ scenario, setScenario }: Props) {
     const updateStep = (index: number, changes: Partial<ScenarioStep>) => {
-        const updated = scenario.map((s, i) => (i === index ? { ...s, ...changes } : s));
+        const updated = scenario.map((s, i) =>
+            i === index ? { ...s, ...changes } : s
+        ) as ScenarioStep[];
         setScenario(updated);
     };
 
@@ -29,15 +31,32 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                         Typ:
                         <select
                             value={step.type}
-                            onChange={(e) =>
-                                updateStep(i, {
-                                    type: e.target.value as ScenarioStep["type"],
-                                })
-                            }
+                            onChange={(e) => {
+                                const type = e.target.value as ScenarioStep["type"];
+                                if (type === "controls") {
+                                    updateStep(i, {
+                                        type,
+                                        from: {
+                                            responsiveness: DEFAULTS.responsiveness,
+                                            noise: DEFAULTS.noise,
+                                            offset: DEFAULTS.offset,
+                                            alarmMargin: DEFAULTS.alarmMargin,
+                                        },
+                                        to: {
+                                            responsiveness: DEFAULTS.responsiveness,
+                                            noise: DEFAULTS.noise,
+                                            offset: DEFAULTS.offset,
+                                            alarmMargin: DEFAULTS.alarmMargin,
+                                        },
+                                    } as ScenarioStep);
+                                } else {
+                                    updateStep(i, { type, from: 0, to: 0 } as ScenarioStep);
+                                }
+                            }}
                         >
                             <option value="carbon">Kolhalt</option>
                             <option value="temperature">Temperatur</option>
-                            <option value="value">Kolvärde</option>
+                            <option value="controls">Manipulering</option>
                         </select>
                     </label>
                     <label>
@@ -80,34 +99,148 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                             </label>
                         </div>
                     )}
-                    {step.type === "value" && (
-                        <div className="field-pair">
-                            <label>
-                                Från:
-                                <input
-                                    type="number"
-                                    step={0.01}
-                                    min={-1}
-                                    max={1}
-                                    value={step.from}
-                                    onChange={(e) =>
-                                        updateStep(i, { from: +e.target.value })
-                                    }
-                                />
-                            </label>
-                            <label>
-                                Till:
-                                <input
-                                    type="number"
-                                    step={0.01}
-                                    min={-1}
-                                    max={1}
-                                    value={step.to}
-                                    onChange={(e) =>
-                                        updateStep(i, { to: +e.target.value })
-                                    }
-                                />
-                            </label>
+                    {step.type === "controls" && (
+                        <div className="controls-fields">
+                            <div className="field-pair">
+                                <label>
+                                    Responsiveness från:
+                                    <input
+                                        type="number"
+                                        step={0.01}
+                                        min={0}
+                                        max={1}
+                                        value={step.from.responsiveness}
+                                        onChange={(e) =>
+                                            updateStep(i, {
+                                                from: {
+                                                    ...step.from,
+                                                    responsiveness: +e.target.value,
+                                                },
+                                            })
+                                        }
+                                    />
+                                </label>
+                                <label>
+                                    till:
+                                    <input
+                                        type="number"
+                                        step={0.01}
+                                        min={0}
+                                        max={1}
+                                        value={step.to.responsiveness}
+                                        onChange={(e) =>
+                                            updateStep(i, {
+                                                to: {
+                                                    ...step.to,
+                                                    responsiveness: +e.target.value,
+                                                },
+                                            })
+                                        }
+                                    />
+                                </label>
+                            </div>
+                            <div className="field-pair">
+                                <label>
+                                    Noise från:
+                                    <input
+                                        type="number"
+                                        step={0.01}
+                                        min={0}
+                                        max={1}
+                                        value={step.from.noise}
+                                        onChange={(e) =>
+                                            updateStep(i, {
+                                                from: { ...step.from, noise: +e.target.value },
+                                            })
+                                        }
+                                    />
+                                </label>
+                                <label>
+                                    till:
+                                    <input
+                                        type="number"
+                                        step={0.01}
+                                        min={0}
+                                        max={1}
+                                        value={step.to.noise}
+                                        onChange={(e) =>
+                                            updateStep(i, {
+                                                to: { ...step.to, noise: +e.target.value },
+                                            })
+                                        }
+                                    />
+                                </label>
+                            </div>
+                            <div className="field-pair">
+                                <label>
+                                    Offset från:
+                                    <input
+                                        type="number"
+                                        step={0.01}
+                                        min={-1}
+                                        max={1}
+                                        value={step.from.offset}
+                                        onChange={(e) =>
+                                            updateStep(i, {
+                                                from: { ...step.from, offset: +e.target.value },
+                                            })
+                                        }
+                                    />
+                                </label>
+                                <label>
+                                    till:
+                                    <input
+                                        type="number"
+                                        step={0.01}
+                                        min={-1}
+                                        max={1}
+                                        value={step.to.offset}
+                                        onChange={(e) =>
+                                            updateStep(i, {
+                                                to: { ...step.to, offset: +e.target.value },
+                                            })
+                                        }
+                                    />
+                                </label>
+                            </div>
+                            <div className="field-pair">
+                                <label>
+                                    Alarm-marginal från:
+                                    <input
+                                        type="number"
+                                        step={0.01}
+                                        min={0}
+                                        max={1}
+                                        value={step.from.alarmMargin}
+                                        onChange={(e) =>
+                                            updateStep(i, {
+                                                from: {
+                                                    ...step.from,
+                                                    alarmMargin: +e.target.value,
+                                                },
+                                            })
+                                        }
+                                    />
+                                </label>
+                                <label>
+                                    till:
+                                    <input
+                                        type="number"
+                                        step={0.01}
+                                        min={0}
+                                        max={1}
+                                        value={step.to.alarmMargin}
+                                        onChange={(e) =>
+                                            updateStep(i, {
+                                                to: {
+                                                    ...step.to,
+                                                    alarmMargin: +e.target.value,
+                                                },
+                                            })
+                                        }
+                                    />
+                                </label>
+                            </div>
                         </div>
                     )}
                     <button onClick={() => removeStep(i)}>Ta bort</button>

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -102,215 +102,215 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                         handleDrop(i);
                     }}
                 >
-                    <span
+                    <div
                         className="drag-handle"
                         draggable
                         onDragStart={() => handleDragStart(i)}
                         onDragEnd={() => setDragIndex(null)}
-                    >
-                        ⋮⋮
-                    </span>
-                    <label>
-                        Typ:
-                        <select
-                            value={step.type}
-                            onChange={(e) => {
-                                const type = e.target.value as ScenarioStep["type"];
-                                updateStep(i, {
-                                    type,
-                                    target: 0,
-                                    ramp: 0,
-                                    duration: 0,
-                                    effects: undefined,
-                                } as ScenarioStep);
-                            }}
-                        >
-                            <option value="carbon">Kolhalt</option>
-                            <option value="temperature">Temperatur</option>
-                        </select>
-                    </label>
-                    {(step.type === "carbon" || step.type === "temperature") && (
-                        <>
-                            <label>
-                                Tid till börvärde (min):
-                                <input
-                                    type="number"
-                                    value={step.ramp}
-                                    onChange={(e) =>
-                                        updateStep(i, { ramp: +e.target.value })
-                                    }
-                                />
-                            </label>
-                            <label>
-                                Varaktighet (min):
-                                <input
-                                    type="number"
-                                    value={step.duration}
-                                    onChange={(e) =>
-                                        updateStep(i, { duration: +e.target.value })
-                                    }
-                                />
-                            </label>
-                            <label>
-                                Börvärde:
-                                <input
-                                    type="number"
-                                    step={step.type === "carbon" ? 0.01 : 1}
-                                    min={0}
-                                    max={step.type === "carbon" ? 1.6 : 1600}
-                                    value={step.target}
-                                    onChange={(e) =>
-                                        updateStep(i, { target: +e.target.value })
-                                    }
-                                />
-                            </label>
-                            {step.type === "carbon" && (
-                                <>
-                                    {step.effects?.map((eff, j) => (
-                                        <div key={j} className="controls-fields">
-                                            <div className="field-pair">
-                                                <label>
-                                                    Start (min):
-                                                    <input
-                                                        type="number"
-                                                        min={0}
-                                                        max={step.ramp + step.duration}
-                                                        value={eff.start}
-                                                        onChange={(e) => {
-                                                            const effects = [...(step.effects ?? [])];
-                                                            effects[j] = {
-                                                                ...effects[j],
-                                                                start: +e.target.value,
-                                                            };
-                                                            updateStep(i, { effects });
-                                                        }}
-                                                    />
-                                                </label>
-                                                <label>
-                                                    Varaktighet (min):
-                                                    <input
-                                                        type="number"
-                                                        min={0}
-                                                        value={eff.duration}
-                                                        onChange={(e) => {
-                                                            const effects = [...(step.effects ?? [])];
-                                                            effects[j] = {
-                                                                ...effects[j],
-                                                                duration: +e.target.value,
-                                                            };
-                                                            updateStep(i, { effects });
-                                                        }}
-                                                    />
-                                                </label>
+                    />
+                    <div className="step-body">
+                        <label>
+                            Typ:
+                            <select
+                                value={step.type}
+                                onChange={(e) => {
+                                    const type = e.target.value as ScenarioStep["type"];
+                                    updateStep(i, {
+                                        type,
+                                        target: 0,
+                                        ramp: 0,
+                                        duration: 0,
+                                        effects: undefined,
+                                    } as ScenarioStep);
+                                }}
+                            >
+                                <option value="carbon">Kolhalt</option>
+                                <option value="temperature">Temperatur</option>
+                            </select>
+                        </label>
+                        {(step.type === "carbon" || step.type === "temperature") && (
+                            <>
+                                <label>
+                                    Tid till börvärde (min):
+                                    <input
+                                        type="number"
+                                        value={step.ramp}
+                                        onChange={(e) =>
+                                            updateStep(i, { ramp: +e.target.value })
+                                        }
+                                    />
+                                </label>
+                                <label>
+                                    Varaktighet (min):
+                                    <input
+                                        type="number"
+                                        value={step.duration}
+                                        onChange={(e) =>
+                                            updateStep(i, { duration: +e.target.value })
+                                        }
+                                    />
+                                </label>
+                                <label>
+                                    Börvärde:
+                                    <input
+                                        type="number"
+                                        step={step.type === "carbon" ? 0.01 : 1}
+                                        min={0}
+                                        max={step.type === "carbon" ? 1.6 : 1600}
+                                        value={step.target}
+                                        onChange={(e) =>
+                                            updateStep(i, { target: +e.target.value })
+                                        }
+                                    />
+                                </label>
+                                {step.type === "carbon" && (
+                                    <>
+                                        {step.effects?.map((eff, j) => (
+                                            <div key={j} className="controls-fields">
+                                                <div className="field-pair">
+                                                    <label>
+                                                        Start (min):
+                                                        <input
+                                                            type="number"
+                                                            min={0}
+                                                            max={step.ramp + step.duration}
+                                                            value={eff.start}
+                                                            onChange={(e) => {
+                                                                const effects = [...(step.effects ?? [])];
+                                                                effects[j] = {
+                                                                    ...effects[j],
+                                                                    start: +e.target.value,
+                                                                };
+                                                                updateStep(i, { effects });
+                                                            }}
+                                                        />
+                                                    </label>
+                                                    <label>
+                                                        Varaktighet (min):
+                                                        <input
+                                                            type="number"
+                                                            min={0}
+                                                            value={eff.duration}
+                                                            onChange={(e) => {
+                                                                const effects = [...(step.effects ?? [])];
+                                                                effects[j] = {
+                                                                    ...effects[j],
+                                                                    duration: +e.target.value,
+                                                                };
+                                                                updateStep(i, { effects });
+                                                            }}
+                                                        />
+                                                    </label>
+                                                </div>
+                                                <div className="field-pair">
+                                                    <label>
+                                                        Responsiveness:
+                                                        <input
+                                                            type="number"
+                                                            step={0.01}
+                                                            min={0}
+                                                            max={1}
+                                                            value={eff.responsiveness}
+                                                            onChange={(e) => {
+                                                                const effects = [...(step.effects ?? [])];
+                                                                effects[j] = {
+                                                                    ...effects[j],
+                                                                    responsiveness: +e.target.value,
+                                                                };
+                                                                updateStep(i, { effects });
+                                                            }}
+                                                        />
+                                                    </label>
+                                                    <label>
+                                                        Noise:
+                                                        <input
+                                                            type="number"
+                                                            step={0.01}
+                                                            min={0}
+                                                            max={1}
+                                                            value={eff.noise}
+                                                            onChange={(e) => {
+                                                                const effects = [...(step.effects ?? [])];
+                                                                effects[j] = {
+                                                                    ...effects[j],
+                                                                    noise: +e.target.value,
+                                                                };
+                                                                updateStep(i, { effects });
+                                                            }}
+                                                        />
+                                                    </label>
+                                                </div>
+                                                <div className="field-pair">
+                                                    <label>
+                                                        Offset:
+                                                        <input
+                                                            type="number"
+                                                            step={0.01}
+                                                            min={-1}
+                                                            max={1}
+                                                            value={eff.offset}
+                                                            onChange={(e) => {
+                                                                const effects = [...(step.effects ?? [])];
+                                                                effects[j] = {
+                                                                    ...effects[j],
+                                                                    offset: +e.target.value,
+                                                                };
+                                                                updateStep(i, { effects });
+                                                            }}
+                                                        />
+                                                    </label>
+                                                    <label>
+                                                        Alarm-marginal:
+                                                        <input
+                                                            type="number"
+                                                            step={0.01}
+                                                            min={0}
+                                                            max={1}
+                                                            value={eff.alarmMargin}
+                                                            onChange={(e) => {
+                                                                const effects = [...(step.effects ?? [])];
+                                                                effects[j] = {
+                                                                    ...effects[j],
+                                                                    alarmMargin: +e.target.value,
+                                                                };
+                                                                updateStep(i, { effects });
+                                                            }}
+                                                        />
+                                                    </label>
+                                                </div>
+                                                <button
+                                                    onClick={() => {
+                                                        const effects = [...(step.effects ?? [])];
+                                                        effects.splice(j, 1);
+                                                        updateStep(i, { effects });
+                                                    }}
+                                                >
+                                                    Ta bort manipulering
+                                                </button>
                                             </div>
-                                            <div className="field-pair">
-                                                <label>
-                                                    Responsiveness:
-                                                    <input
-                                                        type="number"
-                                                        step={0.01}
-                                                        min={0}
-                                                        max={1}
-                                                        value={eff.responsiveness}
-                                                        onChange={(e) => {
-                                                            const effects = [...(step.effects ?? [])];
-                                                            effects[j] = {
-                                                                ...effects[j],
-                                                                responsiveness: +e.target.value,
-                                                            };
-                                                            updateStep(i, { effects });
-                                                        }}
-                                                    />
-                                                </label>
-                                                <label>
-                                                    Noise:
-                                                    <input
-                                                        type="number"
-                                                        step={0.01}
-                                                        min={0}
-                                                        max={1}
-                                                        value={eff.noise}
-                                                        onChange={(e) => {
-                                                            const effects = [...(step.effects ?? [])];
-                                                            effects[j] = {
-                                                                ...effects[j],
-                                                                noise: +e.target.value,
-                                                            };
-                                                            updateStep(i, { effects });
-                                                        }}
-                                                    />
-                                                </label>
-                                            </div>
-                                            <div className="field-pair">
-                                                <label>
-                                                    Offset:
-                                                    <input
-                                                        type="number"
-                                                        step={0.01}
-                                                        min={-1}
-                                                        max={1}
-                                                        value={eff.offset}
-                                                        onChange={(e) => {
-                                                            const effects = [...(step.effects ?? [])];
-                                                            effects[j] = {
-                                                                ...effects[j],
-                                                                offset: +e.target.value,
-                                                            };
-                                                            updateStep(i, { effects });
-                                                        }}
-                                                    />
-                                                </label>
-                                                <label>
-                                                    Alarm-marginal:
-                                                    <input
-                                                        type="number"
-                                                        step={0.01}
-                                                        min={0}
-                                                        max={1}
-                                                        value={eff.alarmMargin}
-                                                        onChange={(e) => {
-                                                            const effects = [...(step.effects ?? [])];
-                                                            effects[j] = {
-                                                                ...effects[j],
-                                                                alarmMargin: +e.target.value,
-                                                            };
-                                                            updateStep(i, { effects });
-                                                        }}
-                                                    />
-                                                </label>
-                                            </div>
-                                            <button
-                                                onClick={() => {
-                                                    const effects = [...(step.effects ?? [])];
-                                                    effects.splice(j, 1);
-                                                    updateStep(i, { effects });
-                                                }}
-                                            >
-                                                Ta bort manipulering
-                                            </button>
-                                        </div>
-                                    ))}
-                                    <button
-                                        onClick={() => {
-                                            const effects = [...(step.effects ?? [])];
-                                            effects.push({
-                                                start: 0,
-                                                duration: 0,
-                                                responsiveness: DEFAULTS.responsiveness,
-                                                noise: DEFAULTS.noise,
-                                                offset: DEFAULTS.offset,
-                                                alarmMargin: DEFAULTS.alarmMargin,
-                                            });
-                                            updateStep(i, { effects });
-                                        }}
-                                    >
-                                        Lägg till manipulering
-                                    </button>
-                                </>
-                            )}
-                        </>
-                    )}
-                    <button onClick={() => removeStep(i)}>Ta bort</button>
+                                        ))}
+                                        <button
+                                            onClick={() => {
+                                                const effects = [...(step.effects ?? [])];
+                                                effects.push({
+                                                    start: 0,
+                                                    duration: 0,
+                                                    responsiveness: DEFAULTS.responsiveness,
+                                                    noise: DEFAULTS.noise,
+                                                    offset: DEFAULTS.offset,
+                                                    alarmMargin: DEFAULTS.alarmMargin,
+                                                });
+                                                updateStep(i, { effects });
+                                            }}
+                                        >
+                                            Lägg till manipulering
+                                        </button>
+                                    </>
+                                )}
+                            </>
+                        )}
+                        <button onClick={() => removeStep(i)}>Ta bort</button>
+                    </div>
                 </div>
             ))}
             <button onClick={addStep}>Lägg till steg</button>

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -114,7 +114,7 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                                     target: 0,
                                     ramp: 0,
                                     duration: 0,
-                                    effect: undefined,
+                                    effects: undefined,
                                 } as ScenarioStep);
                             }}
                         >
@@ -159,140 +159,146 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                             </label>
                             {step.type === "carbon" && (
                                 <>
-                                    <label>
-                                        Manipulering från (min):
-                                        <input
-                                            type="number"
-                                            min={0}
-                                            max={step.ramp + step.duration}
-                                            value={step.effect?.start ?? 0}
-                                            onChange={(e) =>
-                                                updateStep(i, {
-                                                    effect: {
-                                                        ...(step.effect ?? {
-                                                            responsiveness:
-                                                                DEFAULTS.responsiveness,
-                                                            noise: DEFAULTS.noise,
-                                                            offset: DEFAULTS.offset,
-                                                            alarmMargin:
-                                                                DEFAULTS.alarmMargin,
-                                                        }),
-                                                        start: +e.target.value,
-                                                    },
-                                                })
-                                            }
-                                        />
-                                    </label>
-                                    <div className="controls-fields">
-                                        <div className="field-pair">
-                                            <label>
-                                                Responsiveness:
-                                                <input
-                                                    type="number"
-                                                    step={0.01}
-                                                    min={0}
-                                                    max={1}
-                                                    value={step.effect?.responsiveness ?? DEFAULTS.responsiveness}
-                                                    onChange={(e) =>
-                                                        updateStep(i, {
-                                                            effect: {
-                                                                ...(step.effect ?? {
-                                                                    start: 0,
-                                                                    noise:
-                                                                        DEFAULTS.noise,
-                                                                    offset:
-                                                                        DEFAULTS.offset,
-                                                                    alarmMargin:
-                                                                        DEFAULTS.alarmMargin,
-                                                                }),
-                                                                responsiveness:
-                                                                    +e.target.value,
-                                                            },
-                                                        })
-                                                    }
-                                                />
-                                            </label>
-                                            <label>
-                                                Noise:
-                                                <input
-                                                    type="number"
-                                                    step={0.01}
-                                                    min={0}
-                                                    max={1}
-                                                    value={step.effect?.noise ?? DEFAULTS.noise}
-                                                    onChange={(e) =>
-                                                        updateStep(i, {
-                                                            effect: {
-                                                                ...(step.effect ?? {
-                                                                    start: 0,
-                                                                    responsiveness:
-                                                                        DEFAULTS.responsiveness,
-                                                                    offset:
-                                                                        DEFAULTS.offset,
-                                                                    alarmMargin:
-                                                                        DEFAULTS.alarmMargin,
-                                                                }),
+                                    {step.effects?.map((eff, j) => (
+                                        <div key={j} className="controls-fields">
+                                            <div className="field-pair">
+                                                <label>
+                                                    Start (min):
+                                                    <input
+                                                        type="number"
+                                                        min={0}
+                                                        max={step.ramp + step.duration}
+                                                        value={eff.start}
+                                                        onChange={(e) => {
+                                                            const effects = [...(step.effects ?? [])];
+                                                            effects[j] = {
+                                                                ...effects[j],
+                                                                start: +e.target.value,
+                                                            };
+                                                            updateStep(i, { effects });
+                                                        }}
+                                                    />
+                                                </label>
+                                                <label>
+                                                    Varaktighet (min):
+                                                    <input
+                                                        type="number"
+                                                        min={0}
+                                                        value={eff.duration}
+                                                        onChange={(e) => {
+                                                            const effects = [...(step.effects ?? [])];
+                                                            effects[j] = {
+                                                                ...effects[j],
+                                                                duration: +e.target.value,
+                                                            };
+                                                            updateStep(i, { effects });
+                                                        }}
+                                                    />
+                                                </label>
+                                            </div>
+                                            <div className="field-pair">
+                                                <label>
+                                                    Responsiveness:
+                                                    <input
+                                                        type="number"
+                                                        step={0.01}
+                                                        min={0}
+                                                        max={1}
+                                                        value={eff.responsiveness}
+                                                        onChange={(e) => {
+                                                            const effects = [...(step.effects ?? [])];
+                                                            effects[j] = {
+                                                                ...effects[j],
+                                                                responsiveness: +e.target.value,
+                                                            };
+                                                            updateStep(i, { effects });
+                                                        }}
+                                                    />
+                                                </label>
+                                                <label>
+                                                    Noise:
+                                                    <input
+                                                        type="number"
+                                                        step={0.01}
+                                                        min={0}
+                                                        max={1}
+                                                        value={eff.noise}
+                                                        onChange={(e) => {
+                                                            const effects = [...(step.effects ?? [])];
+                                                            effects[j] = {
+                                                                ...effects[j],
                                                                 noise: +e.target.value,
-                                                            },
-                                                        })
-                                                    }
-                                                />
-                                            </label>
-                                        </div>
-                                        <div className="field-pair">
-                                            <label>
-                                                Offset:
-                                                <input
-                                                    type="number"
-                                                    step={0.01}
-                                                    min={-1}
-                                                    max={1}
-                                                    value={step.effect?.offset ?? DEFAULTS.offset}
-                                                    onChange={(e) =>
-                                                        updateStep(i, {
-                                                            effect: {
-                                                                ...(step.effect ?? {
-                                                                    start: 0,
-                                                                    responsiveness:
-                                                                        DEFAULTS.responsiveness,
-                                                                    noise: DEFAULTS.noise,
-                                                                    alarmMargin:
-                                                                        DEFAULTS.alarmMargin,
-                                                                }),
+                                                            };
+                                                            updateStep(i, { effects });
+                                                        }}
+                                                    />
+                                                </label>
+                                            </div>
+                                            <div className="field-pair">
+                                                <label>
+                                                    Offset:
+                                                    <input
+                                                        type="number"
+                                                        step={0.01}
+                                                        min={-1}
+                                                        max={1}
+                                                        value={eff.offset}
+                                                        onChange={(e) => {
+                                                            const effects = [...(step.effects ?? [])];
+                                                            effects[j] = {
+                                                                ...effects[j],
                                                                 offset: +e.target.value,
-                                                            },
-                                                        })
-                                                    }
-                                                />
-                                            </label>
-                                            <label>
-                                                Alarm-marginal:
-                                                <input
-                                                    type="number"
-                                                    step={0.01}
-                                                    min={0}
-                                                    max={1}
-                                                    value={step.effect?.alarmMargin ?? DEFAULTS.alarmMargin}
-                                                    onChange={(e) =>
-                                                        updateStep(i, {
-                                                            effect: {
-                                                                ...(step.effect ?? {
-                                                                    start: 0,
-                                                                    responsiveness:
-                                                                        DEFAULTS.responsiveness,
-                                                                    noise: DEFAULTS.noise,
-                                                                    offset:
-                                                                        DEFAULTS.offset,
-                                                                }),
-                                                                alarmMargin:
-                                                                    +e.target.value,
-                                                            },
-                                                        })
-                                                    }
-                                                />
-                                            </label>
+                                                            };
+                                                            updateStep(i, { effects });
+                                                        }}
+                                                    />
+                                                </label>
+                                                <label>
+                                                    Alarm-marginal:
+                                                    <input
+                                                        type="number"
+                                                        step={0.01}
+                                                        min={0}
+                                                        max={1}
+                                                        value={eff.alarmMargin}
+                                                        onChange={(e) => {
+                                                            const effects = [...(step.effects ?? [])];
+                                                            effects[j] = {
+                                                                ...effects[j],
+                                                                alarmMargin: +e.target.value,
+                                                            };
+                                                            updateStep(i, { effects });
+                                                        }}
+                                                    />
+                                                </label>
+                                            </div>
+                                            <button
+                                                onClick={() => {
+                                                    const effects = [...(step.effects ?? [])];
+                                                    effects.splice(j, 1);
+                                                    updateStep(i, { effects });
+                                                }}
+                                            >
+                                                Ta bort manipulering
+                                            </button>
                                         </div>
-                                    </div>
+                                    ))}
+                                    <button
+                                        onClick={() => {
+                                            const effects = [...(step.effects ?? [])];
+                                            effects.push({
+                                                start: 0,
+                                                duration: 0,
+                                                responsiveness: DEFAULTS.responsiveness,
+                                                noise: DEFAULTS.noise,
+                                                offset: DEFAULTS.offset,
+                                                alarmMargin: DEFAULTS.alarmMargin,
+                                            });
+                                            updateStep(i, { effects });
+                                        }}
+                                    >
+                                        Lägg till manipulering
+                                    </button>
                                 </>
                             )}
                         </>

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -91,18 +91,25 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                     />
                 </label>
             </div>
+            <p className="drag-hint">Dra och släpp stegen för att ändra ordning</p>
             {scenario.steps.map((step, i) => (
                 <div
                     key={i}
-                    className="scenario-step"
-                    draggable
-                    onDragStart={() => handleDragStart(i)}
+                    className={`scenario-step ${dragIndex === i ? "dragging" : ""}`}
                     onDragOver={allowDrop}
                     onDrop={(e) => {
                         e.stopPropagation();
                         handleDrop(i);
                     }}
                 >
+                    <span
+                        className="drag-handle"
+                        draggable
+                        onDragStart={() => handleDragStart(i)}
+                        onDragEnd={() => setDragIndex(null)}
+                    >
+                        ⋮⋮
+                    </span>
                     <label>
                         Typ:
                         <select

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -1,4 +1,4 @@
-import { type ScenarioStep, DEFAULTS } from "../hooks/useSimulation";
+import { type ScenarioStep } from "../hooks/useSimulation";
 
 type Props = {
     scenario: ScenarioStep[];
@@ -6,60 +6,16 @@ type Props = {
 };
 
 export default function ScenarioEditor({ scenario, setScenario }: Props) {
-    const updateStep = (
-        index: number,
-        field: keyof ScenarioStep,
-        value: number
-    ) => {
-        const updated = scenario.map((step, i) =>
-            i === index ? { ...step, [field]: value } : step
-        );
+    const updateStep = (index: number, changes: Partial<ScenarioStep>) => {
+        const updated = scenario.map((s, i) => (i === index ? { ...s, ...changes } : s));
         setScenario(updated);
     };
 
     const addStep = () =>
         setScenario([
             ...scenario,
-            {
-                duration: 10,
-                tempFrom: 0,
-                tempTo: 0,
-                carbonFrom: 0,
-                carbonTo: 0,
-                responsivenessFrom: DEFAULTS.responsiveness,
-                responsivenessTo: DEFAULTS.responsiveness,
-                noiseFrom: DEFAULTS.noise,
-                noiseTo: DEFAULTS.noise,
-                offsetFrom: DEFAULTS.offset,
-                offsetTo: DEFAULTS.offset,
-                alarmMarginFrom: DEFAULTS.alarmMargin,
-                alarmMarginTo: DEFAULTS.alarmMargin,
-            },
+            { type: "carbon", duration: 10, from: 0, to: 0 } as ScenarioStep,
         ]);
-
-    const fieldDefs: {
-        from: keyof ScenarioStep;
-        to: keyof ScenarioStep;
-        label: string;
-        step?: string;
-    }[] = [
-        { from: "tempFrom", to: "tempTo", label: "Temp" },
-        { from: "carbonFrom", to: "carbonTo", label: "Kolhalt", step: "0.01" },
-        {
-            from: "responsivenessFrom",
-            to: "responsivenessTo",
-            label: "Respons",
-            step: "0.01",
-        },
-        { from: "noiseFrom", to: "noiseTo", label: "Brus", step: "0.01" },
-        { from: "offsetFrom", to: "offsetTo", label: "Offset", step: "0.01" },
-        {
-            from: "alarmMarginFrom",
-            to: "alarmMarginTo",
-            label: "Alarm-marginal",
-            step: "0.01",
-        },
-    ];
 
     const removeStep = (index: number) =>
         setScenario(scenario.filter((_, i) => i !== index));
@@ -70,59 +26,90 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
             {scenario.map((step, i) => (
                 <div key={i} className="scenario-step">
                     <label>
+                        Typ:
+                        <select
+                            value={step.type}
+                            onChange={(e) =>
+                                updateStep(i, {
+                                    type: e.target.value as ScenarioStep["type"],
+                                })
+                            }
+                        >
+                            <option value="carbon">Kolhalt</option>
+                            <option value="temperature">Temperatur</option>
+                            <option value="value">Kolvärde</option>
+                        </select>
+                    </label>
+                    <label>
                         Tid (min):
                         <input
                             type="number"
                             value={step.duration}
                             onChange={(e) =>
-                                updateStep(i, "duration", +e.target.value)
+                                updateStep(i, { duration: +e.target.value })
                             }
                         />
                     </label>
-                    {fieldDefs.map(({ from, to, label, step: stepVal }) => (
-                        <div key={from} className="field-pair">
+                    {(step.type === "carbon" || step.type === "temperature") && (
+                        <div className="field-pair">
                             <label>
-                                {label} från:
+                                Från:
                                 <input
                                     type="number"
-                                    step={stepVal}
-                                    value={
-                                        (step as Record<
-                                            keyof ScenarioStep,
-                                            number | undefined
-                                        >)[from] ?? 0
-                                    }
+                                    step={step.type === "carbon" ? 0.01 : 1}
+                                    min={0}
+                                    max={step.type === "carbon" ? 1.6 : 1600}
+                                    value={step.from}
                                     onChange={(e) =>
-                                        updateStep(
-                                            i,
-                                            from as keyof ScenarioStep,
-                                            +e.target.value
-                                        )
+                                        updateStep(i, { from: +e.target.value })
                                     }
                                 />
                             </label>
                             <label>
-                                {label} till:
+                                Till:
                                 <input
                                     type="number"
-                                    step={stepVal}
-                                    value={
-                                        (step as Record<
-                                            keyof ScenarioStep,
-                                            number | undefined
-                                        >)[to] ?? 0
-                                    }
+                                    step={step.type === "carbon" ? 0.01 : 1}
+                                    min={0}
+                                    max={step.type === "carbon" ? 1.6 : 1600}
+                                    value={step.to}
                                     onChange={(e) =>
-                                        updateStep(
-                                            i,
-                                            to as keyof ScenarioStep,
-                                            +e.target.value
-                                        )
+                                        updateStep(i, { to: +e.target.value })
                                     }
                                 />
                             </label>
                         </div>
-                    ))}
+                    )}
+                    {step.type === "value" && (
+                        <div className="field-pair">
+                            <label>
+                                Från:
+                                <input
+                                    type="number"
+                                    step={0.01}
+                                    min={-1}
+                                    max={1}
+                                    value={step.from}
+                                    onChange={(e) =>
+                                        updateStep(i, { from: +e.target.value })
+                                    }
+                                />
+                            </label>
+                            <label>
+                                Till:
+                                <input
+                                    type="number"
+                                    step={0.01}
+                                    min={-1}
+                                    max={1}
+                                    value={step.to}
+                                    onChange={(e) =>
+                                        updateStep(i, { to: +e.target.value })
+                                    }
+                                />
+                            </label>
+                        </div>
+                    )}
                     <button onClick={() => removeStep(i)}>Ta bort</button>
                 </div>
             ))}

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -1,0 +1,92 @@
+import { type ScenarioStep } from "../hooks/useSimulation";
+
+type Props = {
+    scenario: ScenarioStep[];
+    setScenario: (steps: ScenarioStep[]) => void;
+};
+
+export default function ScenarioEditor({ scenario, setScenario }: Props) {
+    const updateStep = (
+        index: number,
+        field: keyof ScenarioStep,
+        value: number
+    ) => {
+        const updated = scenario.map((step, i) =>
+            i === index ? { ...step, [field]: value } : step
+        );
+        setScenario(updated);
+    };
+
+    const addStep = () =>
+        setScenario([
+            ...scenario,
+            { duration: 10, tempFrom: 0, tempTo: 0, carbonFrom: 0, carbonTo: 0 },
+        ]);
+
+    const removeStep = (index: number) =>
+        setScenario(scenario.filter((_, i) => i !== index));
+
+    return (
+        <div className="scenario-editor">
+            <h3>Scenario</h3>
+            {scenario.map((step, i) => (
+                <div key={i} className="scenario-step">
+                    <label>
+                        Tid (min):
+                        <input
+                            type="number"
+                            value={step.duration}
+                            onChange={(e) =>
+                                updateStep(i, "duration", +e.target.value)
+                            }
+                        />
+                    </label>
+                    <label>
+                        Temp från:
+                        <input
+                            type="number"
+                            value={step.tempFrom}
+                            onChange={(e) =>
+                                updateStep(i, "tempFrom", +e.target.value)
+                            }
+                        />
+                    </label>
+                    <label>
+                        Temp till:
+                        <input
+                            type="number"
+                            value={step.tempTo}
+                            onChange={(e) =>
+                                updateStep(i, "tempTo", +e.target.value)
+                            }
+                        />
+                    </label>
+                    <label>
+                        Kolhalt från:
+                        <input
+                            type="number"
+                            step="0.01"
+                            value={step.carbonFrom}
+                            onChange={(e) =>
+                                updateStep(i, "carbonFrom", +e.target.value)
+                            }
+                        />
+                    </label>
+                    <label>
+                        Kolhalt till:
+                        <input
+                            type="number"
+                            step="0.01"
+                            value={step.carbonTo}
+                            onChange={(e) =>
+                                updateStep(i, "carbonTo", +e.target.value)
+                            }
+                        />
+                    </label>
+                    <button onClick={() => removeStep(i)}>Ta bort</button>
+                </div>
+            ))}
+            <button onClick={addStep}>Lägg till steg</button>
+        </div>
+    );
+}

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -1,4 +1,4 @@
-import { type ScenarioStep } from "../hooks/useSimulation";
+import { type ScenarioStep, DEFAULTS } from "../hooks/useSimulation";
 
 type Props = {
     scenario: ScenarioStep[];
@@ -20,8 +20,46 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
     const addStep = () =>
         setScenario([
             ...scenario,
-            { duration: 10, tempFrom: 0, tempTo: 0, carbonFrom: 0, carbonTo: 0 },
+            {
+                duration: 10,
+                tempFrom: 0,
+                tempTo: 0,
+                carbonFrom: 0,
+                carbonTo: 0,
+                responsivenessFrom: DEFAULTS.responsiveness,
+                responsivenessTo: DEFAULTS.responsiveness,
+                noiseFrom: DEFAULTS.noise,
+                noiseTo: DEFAULTS.noise,
+                offsetFrom: DEFAULTS.offset,
+                offsetTo: DEFAULTS.offset,
+                alarmMarginFrom: DEFAULTS.alarmMargin,
+                alarmMarginTo: DEFAULTS.alarmMargin,
+            },
         ]);
+
+    const fieldDefs: {
+        from: keyof ScenarioStep;
+        to: keyof ScenarioStep;
+        label: string;
+        step?: string;
+    }[] = [
+        { from: "tempFrom", to: "tempTo", label: "Temp" },
+        { from: "carbonFrom", to: "carbonTo", label: "Kolhalt", step: "0.01" },
+        {
+            from: "responsivenessFrom",
+            to: "responsivenessTo",
+            label: "Respons",
+            step: "0.01",
+        },
+        { from: "noiseFrom", to: "noiseTo", label: "Brus", step: "0.01" },
+        { from: "offsetFrom", to: "offsetTo", label: "Offset", step: "0.01" },
+        {
+            from: "alarmMarginFrom",
+            to: "alarmMarginTo",
+            label: "Alarm-marginal",
+            step: "0.01",
+        },
+    ];
 
     const removeStep = (index: number) =>
         setScenario(scenario.filter((_, i) => i !== index));
@@ -41,48 +79,50 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                             }
                         />
                     </label>
-                    <label>
-                        Temp från:
-                        <input
-                            type="number"
-                            value={step.tempFrom}
-                            onChange={(e) =>
-                                updateStep(i, "tempFrom", +e.target.value)
-                            }
-                        />
-                    </label>
-                    <label>
-                        Temp till:
-                        <input
-                            type="number"
-                            value={step.tempTo}
-                            onChange={(e) =>
-                                updateStep(i, "tempTo", +e.target.value)
-                            }
-                        />
-                    </label>
-                    <label>
-                        Kolhalt från:
-                        <input
-                            type="number"
-                            step="0.01"
-                            value={step.carbonFrom}
-                            onChange={(e) =>
-                                updateStep(i, "carbonFrom", +e.target.value)
-                            }
-                        />
-                    </label>
-                    <label>
-                        Kolhalt till:
-                        <input
-                            type="number"
-                            step="0.01"
-                            value={step.carbonTo}
-                            onChange={(e) =>
-                                updateStep(i, "carbonTo", +e.target.value)
-                            }
-                        />
-                    </label>
+                    {fieldDefs.map(({ from, to, label, step: stepVal }) => (
+                        <div key={from} className="field-pair">
+                            <label>
+                                {label} från:
+                                <input
+                                    type="number"
+                                    step={stepVal}
+                                    value={
+                                        (step as Record<
+                                            keyof ScenarioStep,
+                                            number | undefined
+                                        >)[from] ?? 0
+                                    }
+                                    onChange={(e) =>
+                                        updateStep(
+                                            i,
+                                            from as keyof ScenarioStep,
+                                            +e.target.value
+                                        )
+                                    }
+                                />
+                            </label>
+                            <label>
+                                {label} till:
+                                <input
+                                    type="number"
+                                    step={stepVal}
+                                    value={
+                                        (step as Record<
+                                            keyof ScenarioStep,
+                                            number | undefined
+                                        >)[to] ?? 0
+                                    }
+                                    onChange={(e) =>
+                                        updateStep(
+                                            i,
+                                            to as keyof ScenarioStep,
+                                            +e.target.value
+                                        )
+                                    }
+                                />
+                            </label>
+                        </div>
+                    ))}
                     <button onClick={() => removeStep(i)}>Ta bort</button>
                 </div>
             ))}

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -21,9 +21,9 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                 {
                     type: "carbon",
                     start: 0,
-                    duration: 10,
-                    from: scenario.startCarbon,
-                    to: scenario.startCarbon,
+                    target: scenario.startCarbon,
+                    ramp: 10,
+                    duration: 0,
                 } as ScenarioStep,
             ],
         });
@@ -95,7 +95,12 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                                         },
                                     } as ScenarioStep);
                                 } else {
-                                    updateStep(i, { type, from: 0, to: 0 } as ScenarioStep);
+                                    updateStep(i, {
+                                        type,
+                                        target: 0,
+                                        ramp: 0,
+                                        duration: 0,
+                                    } as ScenarioStep);
                                 }
                             }}
                         >
@@ -114,189 +119,198 @@ export default function ScenarioEditor({ scenario, setScenario }: Props) {
                             }
                         />
                     </label>
-                    <label>
-                        Längd (min):
-                        <input
-                            type="number"
-                            value={step.duration}
-                            onChange={(e) =>
-                                updateStep(i, { duration: +e.target.value })
-                            }
-                        />
-                    </label>
                     {(step.type === "carbon" || step.type === "temperature") && (
-                        <div className="field-pair">
+                        <>
                             <label>
-                                Från:
+                                Tid till börvärde (min):
+                                <input
+                                    type="number"
+                                    value={step.ramp}
+                                    onChange={(e) =>
+                                        updateStep(i, { ramp: +e.target.value })
+                                    }
+                                />
+                            </label>
+                            <label>
+                                Varaktighet (min):
+                                <input
+                                    type="number"
+                                    value={step.duration}
+                                    onChange={(e) =>
+                                        updateStep(i, { duration: +e.target.value })
+                                    }
+                                />
+                            </label>
+                            <label>
+                                Börvärde:
                                 <input
                                     type="number"
                                     step={step.type === "carbon" ? 0.01 : 1}
                                     min={0}
                                     max={step.type === "carbon" ? 1.6 : 1600}
-                                    value={step.from}
+                                    value={step.target}
                                     onChange={(e) =>
-                                        updateStep(i, { from: +e.target.value })
+                                        updateStep(i, { target: +e.target.value })
                                     }
                                 />
                             </label>
-                            <label>
-                                Till:
-                                <input
-                                    type="number"
-                                    step={step.type === "carbon" ? 0.01 : 1}
-                                    min={0}
-                                    max={step.type === "carbon" ? 1.6 : 1600}
-                                    value={step.to}
-                                    onChange={(e) =>
-                                        updateStep(i, { to: +e.target.value })
-                                    }
-                                />
-                            </label>
-                        </div>
+                        </>
                     )}
                     {step.type === "controls" && (
-                        <div className="controls-fields">
-                            <div className="field-pair">
-                                <label>
-                                    Responsiveness från:
-                                    <input
-                                        type="number"
-                                        step={0.01}
-                                        min={0}
-                                        max={1}
-                                        value={step.from.responsiveness}
-                                        onChange={(e) =>
-                                            updateStep(i, {
-                                                from: {
-                                                    ...step.from,
-                                                    responsiveness: +e.target.value,
-                                                },
-                                            })
-                                        }
-                                    />
-                                </label>
-                                <label>
-                                    till:
-                                    <input
-                                        type="number"
-                                        step={0.01}
-                                        min={0}
-                                        max={1}
-                                        value={step.to.responsiveness}
-                                        onChange={(e) =>
-                                            updateStep(i, {
-                                                to: {
-                                                    ...step.to,
-                                                    responsiveness: +e.target.value,
-                                                },
-                                            })
-                                        }
-                                    />
-                                </label>
+                        <>
+                            <label>
+                                Varaktighet (min):
+                                <input
+                                    type="number"
+                                    value={step.duration}
+                                    onChange={(e) =>
+                                        updateStep(i, { duration: +e.target.value })
+                                    }
+                                />
+                            </label>
+                            <div className="controls-fields">
+                                <div className="field-pair">
+                                    <label>
+                                        Responsiveness från:
+                                        <input
+                                            type="number"
+                                            step={0.01}
+                                            min={0}
+                                            max={1}
+                                            value={step.from.responsiveness}
+                                            onChange={(e) =>
+                                                updateStep(i, {
+                                                    from: {
+                                                        ...step.from,
+                                                        responsiveness: +e.target.value,
+                                                    },
+                                                })
+                                            }
+                                        />
+                                    </label>
+                                    <label>
+                                        till:
+                                        <input
+                                            type="number"
+                                            step={0.01}
+                                            min={0}
+                                            max={1}
+                                            value={step.to.responsiveness}
+                                            onChange={(e) =>
+                                                updateStep(i, {
+                                                    to: {
+                                                        ...step.to,
+                                                        responsiveness: +e.target.value,
+                                                    },
+                                                })
+                                            }
+                                        />
+                                    </label>
+                                </div>
+                                <div className="field-pair">
+                                    <label>
+                                        Noise från:
+                                        <input
+                                            type="number"
+                                            step={0.01}
+                                            min={0}
+                                            max={1}
+                                            value={step.from.noise}
+                                            onChange={(e) =>
+                                                updateStep(i, {
+                                                    from: { ...step.from, noise: +e.target.value },
+                                                })
+                                            }
+                                        />
+                                    </label>
+                                    <label>
+                                        till:
+                                        <input
+                                            type="number"
+                                            step={0.01}
+                                            min={0}
+                                            max={1}
+                                            value={step.to.noise}
+                                            onChange={(e) =>
+                                                updateStep(i, {
+                                                    to: { ...step.to, noise: +e.target.value },
+                                                })
+                                            }
+                                        />
+                                    </label>
+                                </div>
+                                <div className="field-pair">
+                                    <label>
+                                        Offset från:
+                                        <input
+                                            type="number"
+                                            step={0.01}
+                                            min={-1}
+                                            max={1}
+                                            value={step.from.offset}
+                                            onChange={(e) =>
+                                                updateStep(i, {
+                                                    from: { ...step.from, offset: +e.target.value },
+                                                })
+                                            }
+                                        />
+                                    </label>
+                                    <label>
+                                        till:
+                                        <input
+                                            type="number"
+                                            step={0.01}
+                                            min={-1}
+                                            max={1}
+                                            value={step.to.offset}
+                                            onChange={(e) =>
+                                                updateStep(i, {
+                                                    to: { ...step.to, offset: +e.target.value },
+                                                })
+                                            }
+                                        />
+                                    </label>
+                                </div>
+                                <div className="field-pair">
+                                    <label>
+                                        Alarm-marginal från:
+                                        <input
+                                            type="number"
+                                            step={0.01}
+                                            min={0}
+                                            max={1}
+                                            value={step.from.alarmMargin}
+                                            onChange={(e) =>
+                                                updateStep(i, {
+                                                    from: {
+                                                        ...step.from,
+                                                        alarmMargin: +e.target.value,
+                                                    },
+                                                })
+                                            }
+                                        />
+                                    </label>
+                                    <label>
+                                        till:
+                                        <input
+                                            type="number"
+                                            step={0.01}
+                                            min={0}
+                                            max={1}
+                                            value={step.to.alarmMargin}
+                                            onChange={(e) =>
+                                                updateStep(i, {
+                                                    to: {
+                                                        ...step.to,
+                                                        alarmMargin: +e.target.value,
+                                                    },
+                                                })
+                                            }
+                                        />
+                                    </label>
+                                </div>
                             </div>
-                            <div className="field-pair">
-                                <label>
-                                    Noise från:
-                                    <input
-                                        type="number"
-                                        step={0.01}
-                                        min={0}
-                                        max={1}
-                                        value={step.from.noise}
-                                        onChange={(e) =>
-                                            updateStep(i, {
-                                                from: { ...step.from, noise: +e.target.value },
-                                            })
-                                        }
-                                    />
-                                </label>
-                                <label>
-                                    till:
-                                    <input
-                                        type="number"
-                                        step={0.01}
-                                        min={0}
-                                        max={1}
-                                        value={step.to.noise}
-                                        onChange={(e) =>
-                                            updateStep(i, {
-                                                to: { ...step.to, noise: +e.target.value },
-                                            })
-                                        }
-                                    />
-                                </label>
-                            </div>
-                            <div className="field-pair">
-                                <label>
-                                    Offset från:
-                                    <input
-                                        type="number"
-                                        step={0.01}
-                                        min={-1}
-                                        max={1}
-                                        value={step.from.offset}
-                                        onChange={(e) =>
-                                            updateStep(i, {
-                                                from: { ...step.from, offset: +e.target.value },
-                                            })
-                                        }
-                                    />
-                                </label>
-                                <label>
-                                    till:
-                                    <input
-                                        type="number"
-                                        step={0.01}
-                                        min={-1}
-                                        max={1}
-                                        value={step.to.offset}
-                                        onChange={(e) =>
-                                            updateStep(i, {
-                                                to: { ...step.to, offset: +e.target.value },
-                                            })
-                                        }
-                                    />
-                                </label>
-                            </div>
-                            <div className="field-pair">
-                                <label>
-                                    Alarm-marginal från:
-                                    <input
-                                        type="number"
-                                        step={0.01}
-                                        min={0}
-                                        max={1}
-                                        value={step.from.alarmMargin}
-                                        onChange={(e) =>
-                                            updateStep(i, {
-                                                from: {
-                                                    ...step.from,
-                                                    alarmMargin: +e.target.value,
-                                                },
-                                            })
-                                        }
-                                    />
-                                </label>
-                                <label>
-                                    till:
-                                    <input
-                                        type="number"
-                                        step={0.01}
-                                        min={0}
-                                        max={1}
-                                        value={step.to.alarmMargin}
-                                        onChange={(e) =>
-                                            updateStep(i, {
-                                                to: {
-                                                    ...step.to,
-                                                    alarmMargin: +e.target.value,
-                                                },
-                                            })
-                                        }
-                                    />
-                                </label>
-                            </div>
-                        </div>
+                        </>
                     )}
                     <button onClick={() => removeStep(i)}>Ta bort</button>
                 </div>

--- a/ocss-curves/src/components/ScenarioEditor.tsx
+++ b/ocss-curves/src/components/ScenarioEditor.tsx
@@ -1,31 +1,76 @@
-import { type ScenarioStep, DEFAULTS } from "../hooks/useSimulation";
+import { type ScenarioStep, DEFAULTS, type Scenario } from "../hooks/useSimulation";
 
 type Props = {
-    scenario: ScenarioStep[];
-    setScenario: (steps: ScenarioStep[]) => void;
+    scenario: Scenario;
+    setScenario: (s: Scenario) => void;
 };
 
 export default function ScenarioEditor({ scenario, setScenario }: Props) {
     const updateStep = (index: number, changes: Partial<ScenarioStep>) => {
-        const updated = scenario.map((s, i) =>
+        const updated = scenario.steps.map((s, i) =>
             i === index ? { ...s, ...changes } : s
         ) as ScenarioStep[];
-        setScenario(updated);
+        setScenario({ ...scenario, steps: updated });
     };
 
     const addStep = () =>
-        setScenario([
+        setScenario({
             ...scenario,
-            { type: "carbon", start: 0, duration: 10, from: 0, to: 0 } as ScenarioStep,
-        ]);
+            steps: [
+                ...scenario.steps,
+                {
+                    type: "carbon",
+                    start: 0,
+                    duration: 10,
+                    from: scenario.startCarbon,
+                    to: scenario.startCarbon,
+                } as ScenarioStep,
+            ],
+        });
 
     const removeStep = (index: number) =>
-        setScenario(scenario.filter((_, i) => i !== index));
+        setScenario({
+            ...scenario,
+            steps: scenario.steps.filter((_, i) => i !== index),
+        });
 
     return (
         <div className="scenario-editor">
             <h3>Scenario</h3>
-            {scenario.map((step, i) => (
+            <div className="field-pair">
+                <label>
+                    Starttemperatur:
+                    <input
+                        type="number"
+                        min={0}
+                        max={1600}
+                        value={scenario.startTemp}
+                        onChange={(e) =>
+                            setScenario({
+                                ...scenario,
+                                startTemp: +e.target.value,
+                            })
+                        }
+                    />
+                </label>
+                <label>
+                    Startkolhalt:
+                    <input
+                        type="number"
+                        step={0.01}
+                        min={0}
+                        max={1.6}
+                        value={scenario.startCarbon}
+                        onChange={(e) =>
+                            setScenario({
+                                ...scenario,
+                                startCarbon: +e.target.value,
+                            })
+                        }
+                    />
+                </label>
+            </div>
+            {scenario.steps.map((step, i) => (
                 <div key={i} className="scenario-step">
                     <label>
                         Typ:

--- a/ocss-curves/src/components/Sliders.tsx
+++ b/ocss-curves/src/components/Sliders.tsx
@@ -16,7 +16,7 @@ export default function Sliders({
         <div className="sliders">
             <label>
                 Bör-värde Kolhalt: {carbonTarget.toFixed(2)}
-                <input type="range" min="0" max="2" step="0.01" value={carbonTarget} onChange={(e) => setCarbonTarget(+e.target.value)} />
+                <input type="range" min="0" max="1.6" step="0.01" value={carbonTarget} onChange={(e) => setCarbonTarget(+e.target.value)} />
             </label>
             <label>
                 Responsiveness: {responsiveness.toFixed(2)}

--- a/ocss-curves/src/components/Sliders.tsx
+++ b/ocss-curves/src/components/Sliders.tsx
@@ -1,4 +1,15 @@
-import React from "react";
+type Props = {
+    carbonTarget: number;
+    setCarbonTarget: (v: number) => void;
+    responsiveness: number;
+    setResponsiveness: (v: number) => void;
+    noise: number;
+    setNoise: (v: number) => void;
+    offset: number;
+    setOffset: (v: number) => void;
+    alarmMargin: number;
+    setAlarmMargin: (v: number) => void;
+};
 
 export default function Sliders({
                                     carbonTarget,
@@ -11,7 +22,7 @@ export default function Sliders({
                                     setOffset,
                                     alarmMargin,
                                     setAlarmMargin,
-                                }) {
+                                }: Props) {
     return (
         <div className="sliders">
             <label>

--- a/ocss-curves/src/hooks/useSimulation.ts
+++ b/ocss-curves/src/hooks/useSimulation.ts
@@ -221,18 +221,8 @@ export function useSimulation(
                             }
                         }
                     });
-                    const adjustedCarbon = baseCarbon + offsetVal;
-                    carbonTargetRef.current = adjustedCarbon;
-                    setCarbonTarget(adjustedCarbon);
-
-                    responsivenessRef.current = respVal;
-                    setResponsiveness(respVal);
-                    noiseRef.current = noiseVal;
-                    setNoise(noiseVal);
-                    offsetRef.current = offsetVal;
-                    setOffset(offsetVal);
-                    alarmMarginRef.current = marginVal;
-                    setAlarmMargin(marginVal);
+                    carbonTargetRef.current = baseCarbon;
+                    setCarbonTarget(baseCarbon);
                 } else {
                     const rampTime = 60 * 1000;
                     const progress = Math.min(
@@ -241,10 +231,20 @@ export function useSimulation(
                     );
                     setTemp = progress * targetTempRef.current;
                     baseCarbon = progress * carbonTargetRef.current;
-                    const adjustedCarbon = baseCarbon + offsetVal;
-                    carbonTargetRef.current = adjustedCarbon;
-                    setCarbonTarget(adjustedCarbon);
+                    carbonTargetRef.current = baseCarbon;
+                    setCarbonTarget(baseCarbon);
                 }
+
+                responsivenessRef.current = respVal;
+                setResponsiveness(respVal);
+                noiseRef.current = noiseVal;
+                setNoise(noiseVal);
+                alarmMarginRef.current = marginVal;
+                setAlarmMargin(marginVal);
+
+                const prevOffset = offsetRef.current;
+                offsetRef.current = offsetVal;
+                setOffset(offsetVal);
 
                 const setCarbon = carbonTargetRef.current;
 
@@ -255,14 +255,15 @@ export function useSimulation(
                 // Carbon with filtered noise
                 const drift =
                     1 - Math.exp(-responsivenessRef.current * (stepMs / 1000));
-                const carbonDrift = (setCarbon - lastCarbon) * drift;
+                const baseLast = lastCarbon - prevOffset;
+                const carbonDrift = (setCarbon - baseLast) * drift;
 
                 const randomShock = (Math.random() * 2 - 1) * noiseRef.current;
                 noiseStateRef.current =
                     noiseStateRef.current * 0.9 + randomShock * 0.1;
 
                 const measuredCarbon =
-                    lastCarbon + carbonDrift + noiseStateRef.current;
+                    baseLast + carbonDrift + noiseStateRef.current + offsetRef.current;
 
                 // 10s moving average
                 const windowMs = 10 * 1000;

--- a/ocss-curves/src/hooks/useSimulation.ts
+++ b/ocss-curves/src/hooks/useSimulation.ts
@@ -35,6 +35,12 @@ export type ScenarioStep =
           };
       };
 
+export type Scenario = {
+    startTemp: number;
+    startCarbon: number;
+    steps: ScenarioStep[];
+};
+
 export const DEFAULTS = {
     carbonTarget: 1.2,
     responsiveness: 0.1,
@@ -45,6 +51,7 @@ export const DEFAULTS = {
 
 export function useSimulation(
     initialTemp: number = 860,
+    initialCarbon: number = DEFAULTS.carbonTarget,
     stepMs: number = 100,
     scenario: ScenarioStep[] = []
 ) {
@@ -59,12 +66,20 @@ export function useSimulation(
     useEffect(() => {
         targetTempRef.current = targetTemp;
     }, [targetTemp]);
+    useEffect(() => {
+        targetTempRef.current = initialTemp;
+        setTargetTemp(initialTemp);
+    }, [initialTemp]);
 
-    const [carbonTarget, setCarbonTarget] = useState(DEFAULTS.carbonTarget);
+    const [carbonTarget, setCarbonTarget] = useState(initialCarbon);
     const carbonTargetRef = useRef(carbonTarget);
     useEffect(() => {
         carbonTargetRef.current = carbonTarget;
     }, [carbonTarget]);
+    useEffect(() => {
+        carbonTargetRef.current = initialCarbon;
+        setCarbonTarget(initialCarbon);
+    }, [initialCarbon]);
     const [currentTemp, setCurrentTemp] = useState(0);
     const [currentCarbon, setCurrentCarbon] = useState(0);
     const [avgCarbon, setAvgCarbon] = useState(0);
@@ -275,6 +290,10 @@ export function useSimulation(
             setData([]);
             simTimeRef.current = 0;
             noiseStateRef.current = 0;
+            targetTempRef.current = initialTemp;
+            setTargetTemp(initialTemp);
+            carbonTargetRef.current = initialCarbon;
+            setCarbonTarget(initialCarbon);
             setRunning(true);
             setAlarm(false);
             setAlarmEvents([]);

--- a/ocss-curves/src/hooks/useSimulation.ts
+++ b/ocss-curves/src/hooks/useSimulation.ts
@@ -88,11 +88,6 @@ export function useSimulation(
     useEffect(() => {
         noiseRef.current = noise;
     }, [noise]);
-    const offsetRef = useRef(offset);
-    const prevOffsetRef = useRef(offset);
-    useEffect(() => {
-        offsetRef.current = offset;
-    }, [offset]);
     const alarmMarginRef = useRef(alarmMargin);
     useEffect(() => {
         alarmMarginRef.current = alarmMargin;
@@ -221,7 +216,7 @@ export function useSimulation(
                                 }
                             }
                         }
-                        setCarbon = baseCarbon;
+                        setCarbon = baseCarbon + offsetVal;
                     });
                     carbonTargetRef.current = setCarbon;
                     setCarbonTarget(setCarbon);
@@ -237,7 +232,6 @@ export function useSimulation(
                     setCarbonTarget(baseCarbon);
                 }
 
-                offsetRef.current = offsetVal;
                 setOffset(offsetVal);
 
                 responsivenessRef.current = respVal;
@@ -247,12 +241,6 @@ export function useSimulation(
                 alarmMarginRef.current = marginVal;
                 setAlarmMargin(marginVal);
 
-                const prevOffset = prevOffsetRef.current;
-                const currentOffset = offsetRef.current;
-                prevOffsetRef.current = currentOffset;
-
-                const setCarbonVal = carbonTargetRef.current;
-
                 // Temperature (gentle approach to setpoint)
                 let measuredTemp = lastTemp + (setTemp - lastTemp) * (stepMs / 5000);
                 if (Math.random() < 0.02) measuredTemp += Math.random() * 4 - 2;
@@ -260,13 +248,13 @@ export function useSimulation(
                 // Carbon with noise
                 const drift =
                     1 - Math.exp(-responsivenessRef.current * (stepMs / 1000));
-                const baseLast = lastCarbon - prevOffset;
-                const carbonDrift = (setCarbonVal - baseLast) * drift;
+                const carbonDrift =
+                    (carbonTargetRef.current - lastCarbon) * drift;
 
                 const randomShock = (Math.random() * 2 - 1) * noiseRef.current;
 
                 const measuredCarbon =
-                    baseLast + carbonDrift + randomShock + currentOffset;
+                    lastCarbon + carbonDrift + randomShock;
 
                 // 10s moving average
                 const windowMs = 10 * 1000;

--- a/ocss-curves/src/hooks/useSimulation.ts
+++ b/ocss-curves/src/hooks/useSimulation.ts
@@ -155,6 +155,7 @@ export function useSimulation(
                 let respVal = DEFAULTS.responsiveness;
                 let noiseVal = DEFAULTS.noise;
                 let marginVal = DEFAULTS.alarmMargin;
+                let offsetVal = DEFAULTS.offset;
 
                 if (
                     tempStepsRef.current.length > 0 ||
@@ -203,7 +204,6 @@ export function useSimulation(
                                 (step.target - carbonBase) * progress;
                         }
 
-                        let effective = baseCarbon;
                         if (step.effects) {
                             for (const eff of step.effects) {
                                 const effStart =
@@ -217,12 +217,12 @@ export function useSimulation(
                                     respVal = eff.responsiveness;
                                     noiseVal = eff.noise;
                                     marginVal = eff.alarmMargin;
-                                    effective = baseCarbon + eff.offset;
+                                    offsetVal = eff.offset;
                                     break;
                                 }
                             }
                         }
-                        setCarbon = effective;
+                        setCarbon = baseCarbon;
                     });
                     carbonTargetRef.current = setCarbon;
                     setCarbonTarget(setCarbon);
@@ -237,6 +237,9 @@ export function useSimulation(
                     carbonTargetRef.current = baseCarbon;
                     setCarbonTarget(baseCarbon);
                 }
+
+                offsetRef.current = offsetVal;
+                setOffset(offsetVal);
 
                 responsivenessRef.current = respVal;
                 setResponsiveness(respVal);

--- a/ocss-curves/src/hooks/useSimulation.ts
+++ b/ocss-curves/src/hooks/useSimulation.ts
@@ -221,8 +221,9 @@ export function useSimulation(
                             }
                         }
                     });
-                    carbonTargetRef.current = baseCarbon;
-                    setCarbonTarget(baseCarbon);
+                    const adjustedCarbon = baseCarbon + offsetVal;
+                    carbonTargetRef.current = adjustedCarbon;
+                    setCarbonTarget(adjustedCarbon);
 
                     responsivenessRef.current = respVal;
                     setResponsiveness(respVal);
@@ -240,9 +241,12 @@ export function useSimulation(
                     );
                     setTemp = progress * targetTempRef.current;
                     baseCarbon = progress * carbonTargetRef.current;
+                    const adjustedCarbon = baseCarbon + offsetVal;
+                    carbonTargetRef.current = adjustedCarbon;
+                    setCarbonTarget(adjustedCarbon);
                 }
 
-                const setCarbon = baseCarbon + offsetVal;
+                const setCarbon = carbonTargetRef.current;
 
                 // Temperature (gentle approach to setpoint)
                 let measuredTemp = lastTemp + (setTemp - lastTemp) * (stepMs / 5000);

--- a/ocss-curves/src/hooks/useSimulation.ts
+++ b/ocss-curves/src/hooks/useSimulation.ts
@@ -75,15 +75,17 @@ export function useSimulation(
     const [currentCarbon, setCurrentCarbon] = useState(0);
     const [avgCarbon, setAvgCarbon] = useState(0);
 
-    const [responsiveness, setResponsiveness] = useState(DEFAULTS.responsiveness);
+    const [responsiveness, setResponsiveness] = useState(
+        DEFAULTS.responsiveness
+    );
     const [noise, setNoise] = useState(DEFAULTS.noise);
     const [offset, setOffset] = useState(DEFAULTS.offset);
+    const [alarmMargin, setAlarmMargin] = useState(DEFAULTS.alarmMargin);
+
     const offsetRef = useRef(offset);
     useEffect(() => {
         offsetRef.current = offset;
     }, [offset]);
-
-    const [alarmMargin, setAlarmMargin] = useState(DEFAULTS.alarmMargin);
     const responsivenessRef = useRef(responsiveness);
     useEffect(() => {
         responsivenessRef.current = responsiveness;
@@ -150,10 +152,10 @@ export function useSimulation(
                 let setTemp = targetTempRef.current;
                 let baseCarbon = carbonTargetRef.current;
                 let setCarbon = baseCarbon;
-                let respVal = responsivenessRef.current;
-                let noiseVal = noiseRef.current;
-                let marginVal = alarmMarginRef.current;
-                let offsetVal = offsetRef.current;
+                let respVal = responsiveness;
+                let noiseVal = noise;
+                let marginVal = alarmMargin;
+                let offsetVal = offset;
 
                 if (
                     tempStepsRef.current.length > 0 ||
@@ -236,14 +238,10 @@ export function useSimulation(
                     setCarbonTarget(baseCarbon);
                 }
 
-                setOffset(offsetVal);
-
+                offsetRef.current = offsetVal;
                 responsivenessRef.current = respVal;
-                setResponsiveness(respVal);
                 noiseRef.current = noiseVal;
-                setNoise(noiseVal);
                 alarmMarginRef.current = marginVal;
-                setAlarmMargin(marginVal);
 
                 // Temperature (gentle approach to setpoint)
                 let measuredTemp = lastTemp + (setTemp - lastTemp) * (stepMs / 5000);
@@ -255,7 +253,7 @@ export function useSimulation(
                 const carbonDrift =
                     (carbonTargetRef.current - lastCarbon) * drift;
 
-                const randomShock = (Math.random() * 2 - 1) * noiseRef.current;
+                const randomShock = (Math.random() * 2 - 1) * noiseVal;
 
                 const measuredCarbon =
                     lastCarbon + carbonDrift + randomShock;

--- a/ocss-curves/src/hooks/useSimulation.ts
+++ b/ocss-curves/src/hooks/useSimulation.ts
@@ -101,7 +101,6 @@ export function useSimulation(
     const [alarmEvents, setAlarmEvents] = useState<AlarmEvent[]>([]);
 
     const simTimeRef = useRef(0);
-    const noiseStateRef = useRef(0);
     type TempStep = Extract<ScenarioStep, { type: "temperature" }> & { start: number };
     type CarbonStep = Extract<ScenarioStep, { type: "carbon" }> & { start: number };
 
@@ -258,18 +257,16 @@ export function useSimulation(
                 let measuredTemp = lastTemp + (setTemp - lastTemp) * (stepMs / 5000);
                 if (Math.random() < 0.02) measuredTemp += Math.random() * 4 - 2;
 
-                // Carbon with filtered noise
+                // Carbon with noise
                 const drift =
                     1 - Math.exp(-responsivenessRef.current * (stepMs / 1000));
                 const baseLast = lastCarbon - prevOffset;
                 const carbonDrift = (setCarbonVal - baseLast) * drift;
 
                 const randomShock = (Math.random() * 2 - 1) * noiseRef.current;
-                noiseStateRef.current =
-                    noiseStateRef.current * 0.9 + randomShock * 0.1;
 
                 const measuredCarbon =
-                    baseLast + carbonDrift + noiseStateRef.current + currentOffset;
+                    baseLast + carbonDrift + randomShock + currentOffset;
 
                 // 10s moving average
                 const windowMs = 10 * 1000;
@@ -346,7 +343,6 @@ export function useSimulation(
         reset: () => {
             setData([]);
             simTimeRef.current = 0;
-            noiseStateRef.current = 0;
             targetTempRef.current = initialTemp;
             setTargetTemp(initialTemp);
             carbonTargetRef.current = initialCarbon;

--- a/ocss-curves/src/hooks/useSimulation.ts
+++ b/ocss-curves/src/hooks/useSimulation.ts
@@ -78,6 +78,10 @@ export function useSimulation(
     const [responsiveness, setResponsiveness] = useState(DEFAULTS.responsiveness);
     const [noise, setNoise] = useState(DEFAULTS.noise);
     const [offset, setOffset] = useState(DEFAULTS.offset);
+    const offsetRef = useRef(offset);
+    useEffect(() => {
+        offsetRef.current = offset;
+    }, [offset]);
 
     const [alarmMargin, setAlarmMargin] = useState(DEFAULTS.alarmMargin);
     const responsivenessRef = useRef(responsiveness);
@@ -146,10 +150,10 @@ export function useSimulation(
                 let setTemp = targetTempRef.current;
                 let baseCarbon = carbonTargetRef.current;
                 let setCarbon = baseCarbon;
-                let respVal = DEFAULTS.responsiveness;
-                let noiseVal = DEFAULTS.noise;
-                let marginVal = DEFAULTS.alarmMargin;
-                let offsetVal = DEFAULTS.offset;
+                let respVal = responsivenessRef.current;
+                let noiseVal = noiseRef.current;
+                let marginVal = alarmMarginRef.current;
+                let offsetVal = offsetRef.current;
 
                 if (
                     tempStepsRef.current.length > 0 ||

--- a/ocss-curves/src/index.css
+++ b/ocss-curves/src/index.css
@@ -19,8 +19,8 @@ body {
 
 .scenario-step {
   display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
+  align-items: stretch;
+  gap: 0.75rem;
   padding: 0.5rem;
   margin-bottom: 0.5rem;
   border: 1px solid #ddd;
@@ -33,21 +33,36 @@ body {
 }
 
 .drag-handle {
-  width: 12px;
+  width: 14px;
+  align-self: stretch;
   cursor: grab;
   user-select: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #e0e0e0;
+  border-radius: 4px;
+}
+
+.drag-handle::before {
+  content: "";
+  width: 4px;
+  height: 70%;
   background: repeating-linear-gradient(
-    90deg,
-    #ccc,
-    #ccc 2px,
+    to bottom,
+    #999,
+    #999 2px,
     transparent 2px,
     transparent 4px
   );
-  border-radius: 3px;
+  border-radius: 2px;
 }
 
 .step-body {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .scenario-step label {

--- a/ocss-curves/src/index.css
+++ b/ocss-curves/src/index.css
@@ -7,6 +7,8 @@ body {
   padding: 1rem;
   margin-top: 1rem;
   max-width: 600px;
+  background: #fafafa;
+  border-radius: 4px;
 }
 
 .drag-hint {
@@ -16,11 +18,14 @@ body {
 }
 
 .scenario-step {
-  position: relative;
-  padding: 0.75rem 0.5rem 0.5rem 0.5rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem;
   margin-bottom: 0.5rem;
   border: 1px solid #ddd;
-  background: #fdfdfd;
+  background: #fff;
+  border-radius: 4px;
 }
 
 .scenario-step.dragging {
@@ -28,11 +33,27 @@ body {
 }
 
 .drag-handle {
-  position: absolute;
-  top: 0.25rem;
-  right: 0.25rem;
+  width: 12px;
   cursor: grab;
   user-select: none;
+  background: repeating-linear-gradient(
+    90deg,
+    #ccc,
+    #ccc 2px,
+    transparent 2px,
+    transparent 4px
+  );
+  border-radius: 3px;
+}
+
+.step-body {
+  flex: 1;
+}
+
+.scenario-step label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
 }
 
 .field-pair {
@@ -45,4 +66,6 @@ body {
   margin-top: 0.5rem;
   padding: 0.5rem;
   border-left: 3px solid #ccc;
+  background: #f7f7f7;
+  border-radius: 4px;
 }

--- a/ocss-curves/src/index.css
+++ b/ocss-curves/src/index.css
@@ -1,0 +1,48 @@
+body {
+  font-family: sans-serif;
+}
+
+.scenario-editor {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  margin-top: 1rem;
+  max-width: 600px;
+}
+
+.drag-hint {
+  font-size: 0.9rem;
+  color: #555;
+  margin-bottom: 0.5rem;
+}
+
+.scenario-step {
+  position: relative;
+  padding: 0.75rem 0.5rem 0.5rem 0.5rem;
+  margin-bottom: 0.5rem;
+  border: 1px solid #ddd;
+  background: #fdfdfd;
+}
+
+.scenario-step.dragging {
+  opacity: 0.5;
+}
+
+.drag-handle {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  cursor: grab;
+  user-select: none;
+}
+
+.field-pair {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.controls-fields {
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  border-left: 3px solid #ccc;
+}


### PR DESCRIPTION
## Summary
- display temperature and carbon scales with numeric ticks
- limit carbon target slider to 0-1.6

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Binding element implicitly has an 'any' type, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b83dcb5ff0832cb957911da145f42a